### PR TITLE
Fix fetchWorkflowJobs() limit getting 20 jobs

### DIFF
--- a/api_client/api_client.ts
+++ b/api_client/api_client.ts
@@ -193,6 +193,7 @@ export class Github {
           repo: run.repository.name,
           run_id: run.id,
           attempt_number: run.run_attempt ?? 1,
+          per_page: 100, // MAX per_page num
         });
       });
       const chunkResults = (await Promise.all(promises)).map((res) =>


### PR DESCRIPTION
ref: https://github.com/Kesin11/actions-timeline/issues/186

It seems that I forgot to include the `per_page` option when migrating from actions-timeline.
